### PR TITLE
resolvi problema de overflow do navbar

### DIFF
--- a/themes/pybr/static/css/styles.css
+++ b/themes/pybr/static/css/styles.css
@@ -86,6 +86,7 @@ body {
   background-color: var(--bs-body-bg);
   -webkit-text-size-adjust: 100%;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  overflow-x: hidden;
 }
 
 hr {


### PR DESCRIPTION
Adicionei uma regra de overflow que resolve temporariamente o problema do navbar estar transbordando o tamanho da página e consequentemente quebrando o layout